### PR TITLE
Swap from deprecated method World:getBodyList to World:getBodies

### DIFF
--- a/examples/102_physics_adv.lua
+++ b/examples/102_physics_adv.lua
@@ -83,25 +83,25 @@ function love.keypressed( key )
    if key == "up" then
       myWorld:setGravity(0, -9.81*32)
       gravity="up"
-      for i,v in ipairs(myWorld:getBodyList( )) do
+      for i,v in ipairs(myWorld:getBodies( )) do
         v:setAwake( true )
       end
    elseif key == "down" then
       myWorld:setGravity(0, 9.81*32)
       gravity="down"
-      for i,v in ipairs(myWorld:getBodyList( )) do
+      for i,v in ipairs(myWorld:getBodies( )) do
         v:setAwake( true )
       end
    elseif key == "left" then
       myWorld:setGravity(-9.81*32, 0)
       gravity="left"
-      for i,v in ipairs(myWorld:getBodyList( )) do
+      for i,v in ipairs(myWorld:getBodies( )) do
         v:setAwake( true )
       end
   elseif key == "right" then
       myWorld:setGravity(9.81*32, 0)
       gravity="right"
-      for i,v in ipairs(myWorld:getBodyList( )) do
+      for i,v in ipairs(myWorld:getBodies( )) do
         v:setAwake( true )
       end
    end


### PR DESCRIPTION
Sample output:

```
➜  Development love ./LOVE-Example-Browser 
001_loading_image.lua
002_mouse_getpos.lua
004_mouse_setpos.lua
005_mouse_button.lua
006_cursor_visibility.lua
007_sleeping.lua
008_fps_delta.lua
009_timing.lua
010_key_down.lua
011_animation.lua
012_cursor_change.lua
013_cursor_image.lua
014_keyboard_move.lua
015_image_rotation.lua
016_image_rot_scale.lua
017_font_truetype.lua
018_physics_fire_at.lua
019_physics_move_objs_.lua
051_callbacks_basic.lua
052_callbacks_mouse.lua
053_callbacks_keyboard.lua
100_physics_mini.lua
101_physics_mini_callbacks.lua
102_physics_adv.lua
103_filesystem_lines.lua
104_display_modes.lua
150_shaders.lua
video_test.lua
zzz_filler.lua
LOVE - Warning: examples/102_physics_adv.lua:104: Using deprecated method World:getBodyList (renamed to World:getBodies)
```